### PR TITLE
Fixed Events page horizontal overflow for mobile

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -4,7 +4,7 @@
 	-moz-background-size: cover;
 	-o-background-size: cover;
 	background-size: cover;
-	position: relative;	
+	position: relative;
 	text-transform: uppercase;
 	min-height: 480px;
 }
@@ -24,6 +24,10 @@
 	-moz-transform: translate(-50%, -50%);
 	-o-transform: translate(-50%, -50%);
 	transform: translate(-50%, -50%);
+
+	@media screen and (max-width: 395px) {
+		font-size: 4rem;
+	}
 }
 
 #events-container-2 > .row > .columns{
@@ -61,6 +65,3 @@ img.effect-apollo:hover{
 	-webkit-transform: scale3d(1.05,1.05,1.05);
 	transform: scale3d(1.05,1.05,1.05);
 }
-
-
-


### PR DESCRIPTION
Fixes #40. The problem was that the "EVENTS" font-size was too big causing overflow. 
